### PR TITLE
Add RunOptimize, to shrink binary size of bitmaps when called

### DIFF
--- a/META.json
+++ b/META.json
@@ -2,7 +2,7 @@
    "name": "pg_roaringbitmap",
    "abstract": "A Roaring Bitmap data type",
    "description": "This library contains a single PostgreSQL extension, a Roaring Bitmap data type called 'roaringbitmap', along with some convenience opperators and functions for constructing and handling Roaring Bitmap.",
-   "version": "0.5.4",
+   "version": "0.6.0",
    "maintainer": [
       "Chen Huajun <chjischj@163.com>"
    ],
@@ -12,7 +12,7 @@
          "abstract": "A Roaring Bitmap data type",
          "file": "roaringbitmap--0.5.sql",
          "docfile": "README.md",
-         "version": "0.5.4"
+         "version": "0.6.0"
       }
    },
    "resources": {

--- a/roaringbitmap--0.5--0.6.sql
+++ b/roaringbitmap--0.5--0.6.sql
@@ -1,0 +1,6 @@
+/* roaringbitmap--0.5--0.6 */
+
+CREATE OR REPLACE FUNCTION rb_runoptimize(roaringbitmap)
+  RETURNS roaringbitmap
+  AS 'MODULE_PATHNAME', 'rb_runoptimize'
+  LANGUAGE C STRICT IMMUTABLE PARALLEL SAFE;

--- a/roaringbitmap.c
+++ b/roaringbitmap.c
@@ -2056,7 +2056,7 @@ rb_cardinality_final(PG_FUNCTION_ARGS) {
 
 //bitmap run optimize
 PG_FUNCTION_INFO_V1(rb_runoptimize);
-Datum rb_runoptimize(rb_runoptimize);
+Datum rb_runoptimize(PG_FUNCTION_ARGS);
 
 Datum
 rb_runoptimize(PG_FUNCTION_ARGS) {

--- a/roaringbitmap.c
+++ b/roaringbitmap.c
@@ -2055,11 +2055,11 @@ rb_cardinality_final(PG_FUNCTION_ARGS) {
 }
 
 //bitmap run optimize
-PG_FUNCTION_INFO_V1(rb_or);
-Datum rb_or(rb_runoptimize);
+PG_FUNCTION_INFO_V1(rb_runoptimize);
+Datum rb_runoptimize(rb_runoptimize);
 
 Datum
-rb_or(PG_FUNCTION_ARGS) {
+rb_runoptimize(PG_FUNCTION_ARGS) {
     bytea *serializedbytes = PG_GETARG_BYTEA_P(0);
     roaring_bitmap_t *r;
     bool optimized;

--- a/roaringbitmap.c
+++ b/roaringbitmap.c
@@ -2064,7 +2064,7 @@ rb_runoptimize(PG_FUNCTION_ARGS) {
     roaring_bitmap_t *r;
     bool optimized;
 
-    r = roaring_bitmap_portable_deserialize(VARDATA(serializedbytesin));
+    r = roaring_bitmap_portable_deserialize(VARDATA(serializedbytes));
     if (!r)
         ereport(ERROR,
                 (errcode(ERRCODE_NULL_VALUE_NOT_ALLOWED),

--- a/roaringbitmap.c
+++ b/roaringbitmap.c
@@ -2053,3 +2053,30 @@ rb_cardinality_final(PG_FUNCTION_ARGS) {
         PG_RETURN_INT64(card1);
     }
 }
+
+//bitmap run optimize
+PG_FUNCTION_INFO_V1(rb_or);
+Datum rb_or(rb_runoptimize);
+
+Datum
+rb_or(PG_FUNCTION_ARGS) {
+    bytea *serializedbytes = PG_GETARG_BYTEA_P(0);
+    roaring_bitmap_t *r;
+    bool optimized;
+
+    r = roaring_bitmap_portable_deserialize(VARDATA(serializedbytesin));
+    if (!r)
+        ereport(ERROR,
+                (errcode(ERRCODE_NULL_VALUE_NOT_ALLOWED),
+                        errmsg("bitmap format is error")));
+
+    optimized = roaring_bitmap_run_optimize(r);
+
+    expectedsize = roaring_bitmap_portable_size_in_bytes(r);
+    serializedbytes = (bytea *) palloc(VARHDRSZ + expectedsize);
+    roaring_bitmap_portable_serialize(r, VARDATA(serializedbytes));
+
+    roaring_bitmap_free(r);
+    SET_VARSIZE(serializedbytes, VARHDRSZ + expectedsize);
+    PG_RETURN_BYTEA_P(serializedbytes);
+}

--- a/roaringbitmap.c
+++ b/roaringbitmap.c
@@ -2063,6 +2063,7 @@ rb_runoptimize(PG_FUNCTION_ARGS) {
     bytea *serializedbytes = PG_GETARG_BYTEA_P(0);
     roaring_bitmap_t *r;
     bool optimized;
+    size_t expectedsize;
 
     r = roaring_bitmap_portable_deserialize(VARDATA(serializedbytes));
     if (!r)

--- a/roaringbitmap.control
+++ b/roaringbitmap.control
@@ -1,5 +1,5 @@
 # roaringbitmap extension
 comment = 'support for Roaring Bitmaps'
-default_version = '0.5'
+default_version = '0.6'
 module_pathname = '$libdir/roaringbitmap'
 relocatable = true

--- a/roaringbitmap.h
+++ b/roaringbitmap.h
@@ -23,7 +23,6 @@
 #include "libpq/pqformat.h"
 
 /* must include "roaring.h" before redefine malloc functions */
-#define CROARING_ATOMIC_IMPL 3
 #include "roaring.h"
 
 #ifdef PG_MODULE_MAGIC

--- a/roaringbitmap.h
+++ b/roaringbitmap.h
@@ -23,6 +23,7 @@
 #include "libpq/pqformat.h"
 
 /* must include "roaring.h" before redefine malloc functions */
+#define CROARING_ATOMIC_IMPL 3
 #include "roaring.h"
 
 #ifdef PG_MODULE_MAGIC


### PR DESCRIPTION
Recreated https://github.com/BrandwatchLtd/pg_roaringbitmap/pull/3 because I forgot to force squash merges