### PR TITLE
prepare for version 0.6.0

### DIFF
--- a/META.json
+++ b/META.json
@@ -3,9 +3,7 @@
    "abstract": "A Roaring Bitmap data type",
    "description": "This library contains a single PostgreSQL extension, a Roaring Bitmap data type called 'roaringbitmap', along with some convenience opperators and functions for constructing and handling Roaring Bitmap.",
    "version": "0.6.0",
-   "maintainer": [
-      "Chen Huajun <chjischj@163.com>"
-   ],
+   "croaring_version": "2.0.2",
    "license": "apache_2_0",
    "provides": {
       "pg_roaringbitmap": {
@@ -17,15 +15,14 @@
    },
    "resources": {
       "bugtracker": {
-         "web": "http://github.com/ChenHuajun/pg_roaringbitmap/issues/"
+         "web": "http://github.com/BrandwatchLtd/pg_roaringbitmap/issues/"
       },
       "repository": {
-        "url":  "git://github.com/ChenHuajun/pg_roaringbitmap.git",
-        "web":  "http://github.com/ChenHuajun/pg_roaringbitmap/",
+        "url":  "git://github.com/BrandwatchLtd/pg_roaringbitmap.git",
+        "web":  "http://github.com/BrandwatchLtd/pg_roaringbitmap/",
         "type": "git"
       }
    },
-   "generated_by": "Chen Huajun",
    "meta-spec": {
       "version": "1.0.0",
       "url": "http://pgxn.org/meta/spec.txt"

--- a/README.md
+++ b/README.md
@@ -515,18 +515,3 @@ or
         <td><code>2</code></td>
     </tr>
 </table>
-
-# Cloud Vendor Support
-
-`pg_roaringbitmap` is supported by the following cloud vendors 
-
-- Alibaba Cloud RDS PostgreSQL: https://www.alibabacloud.com/help/doc-detail/142340.htm
-- Huawei Cloud RDS PostgreSQL: https://support.huaweicloud.com/usermanual-rds/rds_09_0045.html
-- Tencent Cloud RDS PostgreSQL: https://cloud.tencent.com/document/product/409/67299
-
-To request support for `pg_roaringbitmap` from other cloud vendors, please see the following:
-
-- Amazon RDS: send an email to rds-postgres-extensions-request@amazon.com with the extension name and use case ([docs](https://aws.amazon.com/rds/postgresql/faqs/))
-- Google Cloud SQL: comment on [this issue](https://issuetracker.google.com/u/1/issues/207403722)
-- DigitalOcean Managed Databases: comment on [this idea](https://ideas.digitalocean.com/app-framework-services/p/postgres-extension-request-pgroaringbitmap)
-- Azure Database for PostgreSQL: comment on [this post](https://feedback.azure.com/d365community/idea/e6f5ff90-da4b-ec11-a819-0022484bf651)


### PR DESCRIPTION
add croaring version, update links to our own url, and remove cloud vendors (which use the original project we forked from)